### PR TITLE
Case Study - Ramy Aboul Naga

### DIFF
--- a/framework/datatypes/datatypes.go
+++ b/framework/datatypes/datatypes.go
@@ -1,0 +1,52 @@
+package datatypes
+
+import (
+	"time"
+)
+
+var Uids = []Uid {
+	OneUid,
+	TwoUid,
+	ThreeUid,
+}
+
+var Map = map[Uid]DataType {
+	OneUid:   &One{},
+	TwoUid:   &Two{},
+	ThreeUid: &Three{},
+}
+
+type Uid string
+
+type Attrs map[string]interface{}
+
+func (a Attrs) Merge(b Attrs) Attrs {
+	for key, value := range b {
+		a[key] = value
+	}
+	
+	return a
+}
+
+type DataType interface {
+	Process()
+	
+	Clone() DataType
+	Sample() DataType
+	Attrs() Attrs
+	SetAttrs(Attrs) error
+}
+
+type Base struct {
+	ProcessedAt time.Time `json:"processed_at"`
+}
+
+func (d *Base) Process() {
+	d.ProcessedAt = time.Now()
+}
+
+func (d Base) Attrs() Attrs {
+	return Attrs {
+		"processed_at": d.ProcessedAt,
+	}
+}

--- a/framework/datatypes/one.go
+++ b/framework/datatypes/one.go
@@ -1,0 +1,44 @@
+package datatypes
+
+var OneUid Uid = "one"
+
+type One struct {
+	Base
+	ClientVersion string `json:"client_version"`
+	Platform      string `json:"platform"`
+	Language      string `json:"language"`
+}
+
+func (d *One) Clone() DataType {
+	return &One {
+		Base {},
+		d.ClientVersion,
+		d.Platform,
+		d.Language,
+	}
+}
+
+func (*One) Sample() DataType {
+	return &One {
+		Base {},
+		"game-1.0",
+		"iphone",
+		"danish",
+	}
+}
+
+func (d *One) Attrs() Attrs {
+	return d.Base.Attrs().Merge(Attrs {
+		"client_version": d.ClientVersion,
+		"platform":       d.Platform,
+		"language":       d.Language,
+	})
+}
+
+func (d *One) SetAttrs(data Attrs) error {
+	d.ClientVersion = data["client_version"].(string)
+	d.Platform      = data["platform"].(string)
+	d.Language      = data["language"].(string)
+	
+	return nil
+}

--- a/framework/datatypes/three.go
+++ b/framework/datatypes/three.go
@@ -1,0 +1,40 @@
+package datatypes
+
+import (
+	"time"
+)
+
+var ThreeUid Uid = "three"
+
+type Three struct {
+	Base
+	Timestamp time.Time `json:"timestamp"`
+}
+
+func (d *Three) Clone() DataType {
+	return &Three {
+		Base {},
+		d.Timestamp,
+	}
+}
+
+func (*Three) Sample() DataType {
+	timestamp, _ := time.Parse(time.RFC3339Nano, "2006-01-02T15:04:05.999Z")
+	
+	return &Three {
+		Base {},
+		timestamp,
+	}
+}
+
+func (d *Three) Attrs() Attrs {
+	return d.Base.Attrs().Merge(Attrs {
+		"timestamp": d.Timestamp,
+	})
+}
+
+func (d *Three) SetAttrs(data Attrs) error {
+	d.Timestamp, _ = time.Parse(time.RFC3339Nano, data["timestamp"].(string))
+	
+	return nil
+}

--- a/framework/datatypes/two.go
+++ b/framework/datatypes/two.go
@@ -1,0 +1,39 @@
+package datatypes
+
+var TwoUid Uid = "two"
+
+type Two struct {
+	Base
+	BoostId   int  `json:"boost_id"`
+	Overpower bool `json:"overpower"`
+}
+
+func (d *Two) Clone() DataType {
+	return &Two {
+		Base {},
+		d.BoostId,
+		d.Overpower,
+	}
+}
+
+func (*Two) Sample() DataType {
+	return &Two {
+		Base {},
+		33226,
+		true,
+	}
+}
+
+func (d *Two) Attrs() Attrs {
+	return d.Base.Attrs().Merge(Attrs {
+		"boost_id":  d.BoostId,
+		"overpower": d.Overpower,
+	})
+}
+
+func (d *Two) SetAttrs(data Attrs) error {
+	d.BoostId   = int(data["boost_id"].(float64))
+	d.Overpower = data["overpower"].(bool)
+	
+	return nil
+}

--- a/framework/framework.go
+++ b/framework/framework.go
@@ -26,7 +26,7 @@ func New(newWorkerFunc NewWorkerFunc) *Framework {
 }
 
 func (f *Framework) Run() {
-	log.Printf("[FRAMEWORK] Starting...")
+	log.Printf("[Framework] Starting...")
 
 	for {
 		// create input, output and termination channels
@@ -55,6 +55,6 @@ func (f *Framework) Run() {
 			// no error, stop execution
 			break
 		}
-		log.Printf("[FRAMEWORK] Worker stopped, restarting it: %v", err)
+		log.Printf("[Framework] Worker stopped, restarting it: %v", err)
 	}
 }

--- a/framework/resultsink.go
+++ b/framework/resultsink.go
@@ -1,8 +1,12 @@
 package framework
 
+import (
+	"github.com/fantyz/go-case/framework/datatypes"
+)
+
 type OutData struct {
 	SequenceNumber int
-	Data           map[DataType][]byte
+	Data           map[datatypes.Uid][]byte
 }
 
 type Sink interface {

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -1,9 +1,19 @@
 package worker
 
 import (
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
 	"errors"
 	"github.com/fantyz/go-case/framework"
+	"github.com/fantyz/go-case/framework/datatypes"
 	"log"
+	"time"
+)
+
+const (
+	WorkerBufferMaxSize = 1000
+	WorkerBufferMaxTime = 5 * time.Second
 )
 
 type Worker struct {
@@ -21,8 +31,66 @@ func New(in <-chan *framework.InData, out chan *framework.OutData) framework.Wor
 	}
 }
 
+var (
+	buffer *BufferedOutData = NewBuffer()
+)
+
+type BufferedOutData struct {
+	createdAt          time.Time
+	size               int
+	lastSequenceNumber int
+	outData            map[datatypes.Uid][]datatypes.Attrs
+}
+
+func NewBuffer() *BufferedOutData {
+	newBuffer := BufferedOutData {}
+	newBuffer.Reset()
+	return &newBuffer
+}
+
+func (b *BufferedOutData) Push(dataTypeUid datatypes.Uid, sequenceNumber int, dataType datatypes.DataType, dataTypeAttrs datatypes.Attrs) {
+	b.size++
+	b.lastSequenceNumber = sequenceNumber
+	
+	if err := dataType.SetAttrs(dataTypeAttrs); err != nil {
+		log.Println("[Worker] %v, while parsing: %v\n", err, dataTypeUid)
+		return
+	}
+	
+	dataType.Process()
+	b.outData[dataTypeUid] = append(b.outData[dataTypeUid], dataType.Attrs())
+}
+
+func (b *BufferedOutData) Flush() *framework.OutData {
+	outData := framework.OutData {
+		SequenceNumber: b.lastSequenceNumber,
+		Data:           make(map[datatypes.Uid][]byte, 0),
+	}
+	
+	for dataType, inData := range b.outData {
+		json, _ := json.Marshal(inData)
+		
+		var b bytes.Buffer
+		w := gzip.NewWriter(&b)
+		w.Write(json)
+		w.Close()
+		outData.Data[dataType] = b.Bytes()
+	}
+	
+	b.Reset()
+	
+	return &outData
+}
+
+func (b *BufferedOutData) Reset() {
+	b.createdAt = time.Now()
+	b.size = 0
+	b.lastSequenceNumber = 0
+	b.outData = make(map[datatypes.Uid][]datatypes.Attrs)
+}
+
 func (w *Worker) Run() error {
-	log.Println("Starting worker")
+	log.Println("[Worker] Starting...")
 
 	// read from in channel
 	for in := range w.inChan {
@@ -30,11 +98,25 @@ func (w *Worker) Run() error {
 			// nil indicating worker should simulate a crash by returning an error
 			return errors.New("nil data received, terminating")
 		}
-
+		
+		var inJson map[string]interface{}
+		if err := json.Unmarshal(in.Data, &inJson); err != nil {
+			log.Printf("[Worker] %v\n", err)
+			continue
+		}
+		
+		dataTypeUid := datatypes.Uid(inJson["type"].(string))
+		dataTypeAttrs := datatypes.Attrs(inJson["data"].(map[string]interface{}))
+		buffer.Push(dataTypeUid, in.SequenceNumber, datatypes.Map[dataTypeUid].Clone(), dataTypeAttrs)
+		
 		// write results to result channel
-		w.outChan <- &framework.OutData{}
+		if time.Since(buffer.createdAt) >= WorkerBufferMaxTime || buffer.size >= WorkerBufferMaxSize {
+			w.outChan <- buffer.Flush()
+		}
+		
+//		time.Sleep(500 * time.Millisecond)
 	}
 
-	log.Println("Worker finished")
+	log.Println("[Worker] finished")
 	return nil
 }


### PR DESCRIPTION
#### Challenges
- Read a record from an input channel
- Stamp with a ​processed_at ​timestamp by adding a field to the data
- Batch up (and compress) the finished record based on record type
- When the batch data reaches a certain size it must be sent as a result to the output channel with the last sequence number used

#### Additional Requirements
- In addition to a bundle being converted into a result based on size alone it should also have a timeout (eg. write the batch to the result channel regardless of size if it becomes older than 5 seconds)

#### Bonus Requirements
- Create a data source that is able to generate random data (and errors) into the input data
- Other framework improvements that would improve the quality of the case